### PR TITLE
fix: musl fixes

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -22,7 +22,8 @@ RUN apk add cmake \
     patch \
     coreutils \
     gettext \
-    gettext-dev
+    gettext-dev \
+    gtk-doc
 
 RUN apk add sudo
 RUN adduser -D -u $USER_UID -g $USER_GID $USERNAME \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,7 @@ ExternalProject_Add(criu
         URL ${DEP_criu_URL}
         URL_HASH SHA256=${DEP_criu_SHA256}
         UPDATE_DISCONNECTED 1
-        PATCH_COMMAND patch -p1 -i ${CMAKE_SOURCE_DIR}/patch/criu-build.patch && patch -p1 -i ${CMAKE_SOURCE_DIR}/patch/criu-static-plugin.patch
+        PATCH_COMMAND patch -p1 -i ${CMAKE_SOURCE_DIR}/patch/criu-build.patch && patch -p1 -i ${CMAKE_SOURCE_DIR}/patch/criu-static-plugin.patch && patch -p1 -i ${CMAKE_SOURCE_DIR}/patch/pagehole-fix.patch
         CONFIGURE_COMMAND ""
         DOWNLOAD_DIR ${SOURCE_DOWNLOADS_DIR}
         DOWNLOAD_NAME ${DEP_criu_FILENAME}

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,8 @@ RUN apk add cmake \
     patch \
     coreutils \
     gettext \
-    gettext-dev
+    gettext-dev \
+    gtk-doc
 
 
 RUN mkdir /source

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ this repository will include the musl license in case the main compiler used to 
 
 ```bash
 apk update
-apk add cmake make clang llvm git autoconf automake libtool m4 flex bison pkgconfig bash linux-headers patch coreutils gettext gettext-dev
+apk add cmake make clang llvm git autoconf automake libtool m4 flex bison pkgconfig bash linux-headers patch coreutils gettext gettext-dev gtk-doc
 ```
 
 ### Configure

--- a/check_musl.cmake
+++ b/check_musl.cmake
@@ -29,27 +29,14 @@ function(fetch_musl_license_if_needed)
     if(CMAKE_IS_USING_MUSL)
         message(STATUS "musl libc detected, configuring license installation.")
 
-        set(MUSL_LICENSE_URL "https://git.musl-libc.org/cgit/musl/plain/COPYRIGHT")
-        set(DOWNLOAD_LOCATION "${CMAKE_BINARY_DIR}/musl.COPYRIGHT")
-        install(FILES ${DOWNLOAD_LOCATION} DESTINATION ${CMAKE_INSTALL_DOCDIR}/third_party RENAME musl.COPYRIGHT)
+        set(LOCAL_MUSL_LICENSE "${CMAKE_SOURCE_DIR}/musl.COPYRIGHT")
 
-        if (NOT EXISTS ${DOWNLOAD_LOCATION})
-            message(STATUS "Downloading musl license from ${MUSL_LICENSE_URL} to ${DOWNLOAD_LOCATION}.")
+        if(EXISTS ${LOCAL_MUSL_LICENSE})
+            install(FILES ${LOCAL_MUSL_LICENSE} DESTINATION share/doc/fusion-snapshot)
+            message(STATUS "Using local musl license from ${LOCAL_MUSL_LICENSE}")
         else()
-            message(STATUS "musl license already exists at ${DOWNLOAD_LOCATION}, skipping download.")
-            return()
+            message(WARNING "musl libc detected but local musl.COPYRIGHT file not found at ${LOCAL_MUSL_LICENSE}")
         endif()
-
-        file(DOWNLOAD ${MUSL_LICENSE_URL} ${DOWNLOAD_LOCATION} SHOW_PROGRESS STATUS download_status)
-        
-
-        list(GET download_status 0 download_result)
-        if(NOT download_result EQUAL 0)
-            list(GET download_status 1 error_msg)
-            message(FATAL_ERROR "Failed to download musl license from ${MUSL_LICENSE_URL}. Error: ${error_msg}")
-        endif()
-
-        message(STATUS "musl license downloaded successfully.")
     else()
         message(STATUS "musl libc not detected. Skipping license installation.")
     endif()

--- a/dependencies/Libcap.cmake
+++ b/dependencies/Libcap.cmake
@@ -27,8 +27,8 @@ endif()
 
 register_dependency(
     libcap
-    "https://git.kernel.org/pub/scm/libs/libcap/libcap.git/snapshot/libcap-2.70.tar.gz"
-    "18f00ea97c7541af86379dec9d4d8ea838aac4a1f70177d81d91657e4e43b808"
+    "https://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-2.70.tar.gz"
+    "d3b777ed413c9fafface03b917e171854709b5e4be38dbfb9219aaf7dfd4eea6"
     "License"
 )
 

--- a/dependencies/Libintl.cmake
+++ b/dependencies/Libintl.cmake
@@ -31,7 +31,8 @@ ExternalProject_Add(gettext
     UPDATE_DISCONNECTED 1
     DOWNLOAD_DIR ${SOURCE_DOWNLOADS_DIR}
     DOWNLOAD_NAME ${DEP_gettext_FILENAME}
-    CONFIGURE_COMMAND <SOURCE_DIR>/configure 
+    UPDATE_COMMAND autoreconf -fiv
+    CONFIGURE_COMMAND <SOURCE_DIR>/configure
         --prefix=${LIBINTL_INSTALL_DIR} 
         --disable-shared 
         --enable-static 

--- a/dependencies/ProtobufC.cmake
+++ b/dependencies/ProtobufC.cmake
@@ -36,7 +36,7 @@ ExternalProject_Add(protobuf-c
     UPDATE_DISCONNECTED 1
     DOWNLOAD_DIR ${SOURCE_DOWNLOADS_DIR}
     DOWNLOAD_NAME ${DEP_protobuf-c_FILENAME}
-    UPDATE_COMMAND sh -c "test -f <SOURCE_DIR>/configure || <SOURCE_DIR>/autogen.sh"
+    UPDATE_COMMAND autoreconf -fiv
     CONFIGURE_COMMAND ${CMAKE_COMMAND} -E env
         "protobuf_CFLAGS=$<TARGET_PROPERTY:protobuf::static,CONSUMER_CFLAGS>"
         "protobuf_LIBS=$<TARGET_PROPERTY:protobuf::static,CONSUMER_LDFLAGS>"

--- a/dependencies/UtilLinux.cmake
+++ b/dependencies/UtilLinux.cmake
@@ -22,8 +22,8 @@ endif()
 
 register_dependency(
     util_linux
-    "https://git.kernel.org/pub/scm/utils/util-linux/util-linux.git/snapshot/util-linux-2.41.1.tar.gz"
-    "61a9785cbf04091286ec2bbfb78e87c35e6380f084f38115a4677b90b9ad4437"
+    "https://www.kernel.org/pub/linux/utils/util-linux/v2.41/util-linux-2.41.tar.gz"
+    "c014b5861695b603d0be2ad1e6f10d5838b9d7859e1dd72d01504556817d8a87"
     "COPYING"
 )
 
@@ -33,7 +33,7 @@ ExternalProject_Add(util_linux
     UPDATE_DISCONNECTED 1
     DOWNLOAD_DIR ${SOURCE_DOWNLOADS_DIR}
     DOWNLOAD_NAME ${DEP_util_linux_FILENAME}
-    UPDATE_COMMAND sh -c "test -f <SOURCE_DIR>/configure || <SOURCE_DIR>/autogen.sh"
+    UPDATE_COMMAND autoreconf -fiv
     CONFIGURE_COMMAND <SOURCE_DIR>/configure
         --enable-static
         --disable-shared

--- a/musl.COPYRIGHT
+++ b/musl.COPYRIGHT
@@ -1,0 +1,193 @@
+musl as a whole is licensed under the following standard MIT license:
+
+----------------------------------------------------------------------
+Copyright © 2005-2020 Rich Felker, et al.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+----------------------------------------------------------------------
+
+Authors/contributors include:
+
+A. Wilcox
+Ada Worcester
+Alex Dowad
+Alex Suykov
+Alexander Monakov
+Andre McCurdy
+Andrew Kelley
+Anthony G. Basile
+Aric Belsito
+Arvid Picciani
+Bartosz Brachaczek
+Benjamin Peterson
+Bobby Bingham
+Boris Brezillon
+Brent Cook
+Chris Spiegel
+Clément Vasseur
+Daniel Micay
+Daniel Sabogal
+Daurnimator
+David Carlier
+David Edelsohn
+Denys Vlasenko
+Dmitry Ivanov
+Dmitry V. Levin
+Drew DeVault
+Emil Renner Berthing
+Fangrui Song
+Felix Fietkau
+Felix Janda
+Gianluca Anzolin
+Hauke Mehrtens
+He X
+Hiltjo Posthuma
+Isaac Dunham
+Jaydeep Patil
+Jens Gustedt
+Jeremy Huntwork
+Jo-Philipp Wich
+Joakim Sindholt
+John Spencer
+Julien Ramseier
+Justin Cormack
+Kaarle Ritvanen
+Khem Raj
+Kylie McClain
+Leah Neukirchen
+Luca Barbato
+Luka Perkov
+Lynn Ochs
+M Farkas-Dyck (Strake)
+Mahesh Bodapati
+Markus Wichmann
+Masanori Ogino
+Michael Clark
+Michael Forney
+Mikhail Kremnyov
+Natanael Copa
+Nicholas J. Kain
+orc
+Pascal Cuoq
+Patrick Oppenlander
+Petr Hosek
+Petr Skocik
+Pierre Carrier
+Reini Urban
+Rich Felker
+Richard Pennington
+Ryan Fairfax
+Samuel Holland
+Segev Finer
+Shiz
+sin
+Solar Designer
+Stefan Kristiansson
+Stefan O'Rear
+Szabolcs Nagy
+Timo Teräs
+Trutz Behn
+Will Dietz
+William Haddon
+William Pitcock
+
+Portions of this software are derived from third-party works licensed
+under terms compatible with the above MIT license:
+
+The TRE regular expression implementation (src/regex/reg* and
+src/regex/tre*) is Copyright © 2001-2008 Ville Laurikari and licensed
+under a 2-clause BSD license (license text in the source files). The
+included version has been heavily modified by Rich Felker in 2012, in
+the interests of size, simplicity, and namespace cleanliness.
+
+Much of the math library code (src/math/* and src/complex/*) is
+Copyright © 1993,2004 Sun Microsystems or
+Copyright © 2003-2011 David Schultz or
+Copyright © 2003-2009 Steven G. Kargl or
+Copyright © 2003-2009 Bruce D. Evans or
+Copyright © 2008 Stephen L. Moshier or
+Copyright © 2017-2018 Arm Limited
+and labelled as such in comments in the individual source files. All
+have been licensed under extremely permissive terms.
+
+The ARM memcpy code (src/string/arm/memcpy.S) is Copyright © 2008
+The Android Open Source Project and is licensed under a two-clause BSD
+license. It was taken from Bionic libc, used on Android.
+
+The AArch64 memcpy and memset code (src/string/aarch64/*) are
+Copyright © 1999-2019, Arm Limited.
+
+The implementation of DES for crypt (src/crypt/crypt_des.c) is
+Copyright © 1994 David Burren. It is licensed under a BSD license.
+
+The implementation of blowfish crypt (src/crypt/crypt_blowfish.c) was
+originally written by Solar Designer and placed into the public
+domain. The code also comes with a fallback permissive license for use
+in jurisdictions that may not recognize the public domain.
+
+The smoothsort implementation (src/stdlib/qsort.c) is Copyright © 2011
+Lynn Ochs and is licensed under an MIT-style license.
+
+The x86_64 port was written by Nicholas J. Kain and is licensed under
+the standard MIT terms.
+
+The mips and microblaze ports were originally written by Richard
+Pennington for use in the ellcc project. The original code was adapted
+by Rich Felker for build system and code conventions during upstream
+integration. It is licensed under the standard MIT terms.
+
+The mips64 port was contributed by Imagination Technologies and is
+licensed under the standard MIT terms.
+
+The powerpc port was also originally written by Richard Pennington,
+and later supplemented and integrated by John Spencer. It is licensed
+under the standard MIT terms.
+
+All other files which have no copyright comments are original works
+produced specifically for use as part of this library, written either
+by Rich Felker, the main author of the library, or by one or more
+contibutors listed above. Details on authorship of individual files
+can be found in the git version control history of the project. The
+omission of copyright and license comments in each file is in the
+interest of source tree size.
+
+In addition, permission is hereby granted for all public header files
+(include/* and arch/*/bits/*) and crt files intended to be linked into
+applications (crt/*, ldso/dlstart.c, and arch/*/crt_arch.h) to omit
+the copyright notice and permission notice otherwise required by the
+license, and to use these files without any requirement of
+attribution. These files include substantial contributions from:
+
+Bobby Bingham
+John Spencer
+Nicholas J. Kain
+Rich Felker
+Richard Pennington
+Stefan Kristiansson
+Szabolcs Nagy
+
+all of whom have explicitly granted such permission.
+
+This file previously contained text expressing a belief that most of
+the files covered by the above exception were sufficiently trivial not
+to be subject to copyright, resulting in confusion over whether it
+negated the permissions granted in the license. In the spirit of
+permissive licensing, and of not having licensing issues being an
+obstacle to adoption, that text has been removed.

--- a/patch/pagehole-fix.patch
+++ b/patch/pagehole-fix.patch
@@ -1,0 +1,13 @@
+diff --git a/criu/include/pagemap.h b/criu/include/pagemap.h
+index 3ae15deb9c..fae110108c 100644
+--- a/criu/include/pagemap.h
++++ b/criu/include/pagemap.h
+@@ -121,7 +121,7 @@ extern int dedup_one_iovec(struct page_read *pr, unsigned long base, unsigned lo
+ 
+ static inline unsigned long pagemap_len(PagemapEntry *pe)
+ {
+-	return pe->nr_pages * PAGE_SIZE;
++	return (unsigned long)pe->nr_pages * PAGE_SIZE;
+ }
+ 
+ static inline bool page_read_has_parent(struct page_read *pr)


### PR DESCRIPTION
Includes the patch from https://github.com/checkpoint-restore/criu/pull/2747 to make criu-static work with incremental dumps and downloads the kernel libs from www instead of git because git http requires a challenge to be completed because of AI bots.