### PR TITLE
build: release process to specify CRIU version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,6 +19,35 @@ on:
       - synchronize
       - reopened
 
+  # Manual trigger for custom builds and releases
+  workflow_dispatch:
+    inputs:
+      criu_version:
+        description: 'CRIU version to build (e.g., 4.1)'
+        required: false
+        type: string
+      criu_commit:
+        description: 'CRIU commit/tag to build (overrides version if set)'
+        required: false
+        type: string
+      criu_shasum:
+        description: 'SHA256 checksum for the CRIU source'
+        required: true
+        type: string
+      build_revision:
+        description: 'Build revision suffix (e.g., r1, r2) for build script changes'
+        required: false
+        type: string
+      release_type:
+        description: 'Release type'
+        required: false
+        type: choice
+        default: 'draft'
+        options:
+          - 'none'
+          - 'draft'
+          - 'release'
+
 # avoid running multiple copies of the same workflow in parallel
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -38,6 +67,7 @@ jobs:
         uses: docker/setup-buildx-action@v3.10.0
 
       - name: Build criu
+        if: github.event_name != 'workflow_dispatch'
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -49,6 +79,24 @@ jobs:
           platforms: "linux/amd64"
           cache-from: type=gha,scope=criu-build-image-amd64
           cache-to: type=gha,mode=max,scope=criu-build-image-amd64
+
+      - name: Build criu
+        if: github.event_name == 'workflow_dispatch'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          outputs: type=local,dest=./output
+          file: Dockerfile
+          push: false
+          load: true
+          tags: "criu-build-image-amd64"
+          platforms: "linux/amd64"
+          cache-from: type=gha,scope=criu-build-image-amd64
+          cache-to: type=gha,mode=max,scope=criu-build-image-amd64
+          build-args: |
+            CRIU_VERSION=${{ inputs.criu_version }}
+            CRIU_COMMIT=${{ inputs.criu_commit }}
+            CRIU_SHASUM=${{ inputs.criu_shasum }}
 
       - name: Upload amd64 artifact
         uses: actions/upload-artifact@v4.6.2
@@ -69,6 +117,7 @@ jobs:
         uses: docker/setup-buildx-action@v3.10.0
 
       - name: Build criu
+        if: github.event_name != 'workflow_dispatch'
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -81,6 +130,24 @@ jobs:
           cache-from: type=gha,scope=criu-build-image-arm64
           cache-to: type=gha,mode=max,scope=criu-build-image-arm64
 
+      - name: Build criu
+        if: github.event_name == 'workflow_dispatch'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          outputs: type=local,dest=./output
+          file: Dockerfile
+          push: false
+          load: true
+          tags: "criu-build-image-arm64"
+          platforms: "linux/arm64"
+          cache-from: type=gha,scope=criu-build-image-arm64
+          cache-to: type=gha,mode=max,scope=criu-build-image-arm64
+          build-args: |
+            CRIU_VERSION=${{ inputs.criu_version }}
+            CRIU_COMMIT=${{ inputs.criu_commit }}
+            CRIU_SHASUM=${{ inputs.criu_shasum }}
+
       - name: Upload arm64 artifact
         uses: actions/upload-artifact@v4.6.2
         with:
@@ -89,7 +156,7 @@ jobs:
 
   release:
     name: Release
-    if: "contains(github.event.head_commit.message, '[release]') && ( github.event.ref=='refs/heads/master' || contains(github.event.ref, 'release') )"
+    if: "inputs.release_type != 'none'"
     needs: [build-amd64, build-arm64]
     runs-on: ubuntu-24.04
     permissions:
@@ -103,7 +170,7 @@ jobs:
         with:
           pattern: criu-amd64
           path: dist
-    
+
       - name: Download build artifacts (arm64)
         uses: actions/download-artifact@v4.3.0
         with:
@@ -115,10 +182,23 @@ jobs:
         with:
           java-version: 11
 
-      - name: Version
+      - name: Determine version
         id: version
         run: |
-          VERSION=$(cmake --preset static-release -LA  | grep CRIU_VERSION | cut -d'=' -f2)
+          if [ -n "${{ inputs.criu_commit }}" ]; then
+            BASE_VERSION="${{ inputs.criu_commit }}"
+          elif [ -n "${{ inputs.criu_version }}" ]; then
+            BASE_VERSION="${{ inputs.criu_version }}"
+          else
+            BASE_VERSION=$(cmake --preset static-release -LA  | grep CRIU_VERSION | cut -d'=' -f2)
+          fi
+
+          if [ -n "${{ inputs.build_revision }}" ]; then
+            VERSION="${BASE_VERSION}-${{ inputs.build_revision }}"
+          else
+            VERSION="${BASE_VERSION}"
+          fi
+
           echo "VERSION = $VERSION"
           echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
 
@@ -127,3 +207,4 @@ jobs:
         env:
           JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JRELEASER_PROJECT_VERSION: ${{ steps.version.outputs.VERSION }}
+          JRELEASER_DRAFT: ${{ inputs.release_type == 'draft' }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -97,6 +97,7 @@ jobs:
             CRIU_VERSION=${{ inputs.criu_version }}
             CRIU_COMMIT=${{ inputs.criu_commit }}
             CRIU_SHASUM=${{ inputs.criu_shasum }}
+            BUILD_REVISION=${{ inputs.build_revision }}
 
       - name: Upload amd64 artifact
         uses: actions/upload-artifact@v4.6.2
@@ -147,6 +148,7 @@ jobs:
             CRIU_VERSION=${{ inputs.criu_version }}
             CRIU_COMMIT=${{ inputs.criu_commit }}
             CRIU_SHASUM=${{ inputs.criu_shasum }}
+            BUILD_REVISION=${{ inputs.build_revision }}
 
       - name: Upload arm64 artifact
         uses: actions/upload-artifact@v4.6.2
@@ -156,7 +158,7 @@ jobs:
 
   release:
     name: Release
-    if: "inputs.release_type != 'none'"
+    if: "github.event_name == 'workflow_dispatch' && inputs.release_type != 'none'"
     needs: [build-amd64, build-arm64]
     runs-on: ubuntu-24.04
     permissions:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,9 +4,10 @@ project(criu-static VERSION 4.1)
 include(GNUInstallDirs)
 include(macros/dependencies.cmake)
 
-# Upstream CRIU version and SHA256 checksum
-set(CRIU_VERSION "${PROJECT_VERSION}" CACHE STRING "CRIU version to build")
-set(CRIU_SHASUM "9a3094f3d0aa6cfa8bd5c9b92c05f4a566ad21ee20eb9b2fbc6129a74d1f6dc7")
+# CRIU source configuration, specify either version or commit
+set(CRIU_VERSION "${PROJECT_VERSION}" CACHE STRING "CRIU version to build (e.g., 4.1)")
+set(CRIU_COMMIT "" CACHE STRING "CRIU git commit/tag to build instead of version")
+set(CRIU_SHASUM "9a3094f3d0aa6cfa8bd5c9b92c05f4a566ad21ee20eb9b2fbc6129a74d1f6dc7" CACHE STRING "SHA256 checksum for CRIU source")
 
 # Force static building
 set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build shared libraries" FORCE)
@@ -83,9 +84,16 @@ set(CRIU_MAKE_VARS
         "PREFIX=${CRIU_INSTALL_DIR}"
 )
 
+# Build CRIU URL based on commit or version
+if(CRIU_COMMIT)
+    set(CRIU_URL "https://github.com/checkpoint-restore/criu/archive/${CRIU_COMMIT}.tar.gz")
+else()
+    set(CRIU_URL "https://github.com/checkpoint-restore/criu/archive/refs/tags/v${CRIU_VERSION}.tar.gz")
+endif()
+
 register_dependency(
     criu
-    "https://github.com/checkpoint-restore/criu/archive/refs/tags/v${CRIU_VERSION}.tar.gz"
+    "${CRIU_URL}"
     "${CRIU_SHASUM}"
     "COPYING"
 )
@@ -94,7 +102,7 @@ ExternalProject_Add(criu
         URL ${DEP_criu_URL}
         URL_HASH SHA256=${DEP_criu_SHA256}
         UPDATE_DISCONNECTED 1
-        PATCH_COMMAND patch -p1 -i ${CMAKE_SOURCE_DIR}/patch/criu-build.patch && patch -p1 -i ${CMAKE_SOURCE_DIR}/patch/criu-static-plugin.patch && patch -p1 -i ${CMAKE_SOURCE_DIR}/patch/pagehole-fix.patch
+        PATCH_COMMAND patch -p1 -i ${CMAKE_SOURCE_DIR}/patch/criu-build.patch && patch -p1 -i ${CMAKE_SOURCE_DIR}/patch/criu-static-plugin.patch
         CONFIGURE_COMMAND ""
         DOWNLOAD_DIR ${SOURCE_DOWNLOADS_DIR}
         DOWNLOAD_NAME ${DEP_criu_FILENAME}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ include(macros/dependencies.cmake)
 set(CRIU_VERSION "${PROJECT_VERSION}" CACHE STRING "CRIU version to build (e.g., 4.1)")
 set(CRIU_COMMIT "" CACHE STRING "CRIU git commit/tag to build instead of version")
 set(CRIU_SHASUM "9a3094f3d0aa6cfa8bd5c9b92c05f4a566ad21ee20eb9b2fbc6129a74d1f6dc7" CACHE STRING "SHA256 checksum for CRIU source")
+set(BUILD_REVISION "" CACHE STRING "Build revision suffix (e.g., r1, r2) for build script changes")
 
 # Force static building
 set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build shared libraries" FORCE)
@@ -186,9 +187,22 @@ else()
     set(TARGET_ARCH "${CMAKE_SYSTEM_PROCESSOR}")
 endif()
 
+# Determine effective version for packaging
+if(CRIU_COMMIT)
+    set(EFFECTIVE_VERSION "${CRIU_COMMIT}")
+else()
+    set(EFFECTIVE_VERSION "${CRIU_VERSION}")
+endif()
+
+if(BUILD_REVISION)
+    set(FULL_VERSION "${EFFECTIVE_VERSION}-${BUILD_REVISION}")
+else()
+    set(FULL_VERSION "${EFFECTIVE_VERSION}")
+endif()
+
 # Package
 set(CPACK_PACKAGE_NAME "criu-static")
-set(CPACK_PACKAGE_VERSION "${CRIU_VERSION}")
+set(CPACK_PACKAGE_VERSION "${FULL_VERSION}")
 set(CPACK_PACKAGE_VENDOR "The CRIU Authors")
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Static build of CRIU (Checkpoint/Restore In Userspace)")
 set(CPACK_PACKAGE_DESCRIPTION_FILE "${CMAKE_SOURCE_DIR}/README.md")

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM docker.io/alpine:3.22 AS builder
 ARG CRIU_VERSION
 ARG CRIU_COMMIT
 ARG CRIU_SHASUM
+ARG BUILD_REVISION
 
 RUN apk update
 RUN apk add cmake \
@@ -42,7 +43,8 @@ WORKDIR /source
 RUN cmake --preset static-release \
     ${CRIU_VERSION:+-DCRIU_VERSION="$CRIU_VERSION"} \
     ${CRIU_COMMIT:+-DCRIU_COMMIT="$CRIU_COMMIT"} \
-    ${CRIU_SHASUM:+-DCRIU_SHASUM="$CRIU_SHASUM"}
+    ${CRIU_SHASUM:+-DCRIU_SHASUM="$CRIU_SHASUM"} \
+    ${BUILD_REVISION:+-DBUILD_REVISION="$BUILD_REVISION"}
 
 RUN cmake --build --preset static-release
 RUN cpack --config build/CPackConfig.cmake --verbose -B dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,9 @@
 FROM docker.io/alpine:3.22 AS builder
+
+ARG CRIU_VERSION
+ARG CRIU_COMMIT
+ARG CRIU_SHASUM
+
 RUN apk update
 RUN apk add cmake \
     make \
@@ -33,7 +38,12 @@ COPY package_deps_licenses.cmake.in /source
 COPY check_musl.cmake /source
 
 WORKDIR /source
-RUN cmake --preset static-release
+
+RUN cmake --preset static-release \
+    ${CRIU_VERSION:+-DCRIU_VERSION="$CRIU_VERSION"} \
+    ${CRIU_COMMIT:+-DCRIU_COMMIT="$CRIU_COMMIT"} \
+    ${CRIU_SHASUM:+-DCRIU_SHASUM="$CRIU_SHASUM"}
+
 RUN cmake --build --preset static-release
 RUN cpack --config build/CPackConfig.cmake --verbose -B dist
 RUN rm -Rf dist/_CPack_Packages

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,32 @@
+# Release Instructions
+
+## Creating a Draft Release
+
+1. Go to Actions in this repository
+2. Click "Run workflow"
+3. Fill in the inputs:
+   - **CRIU version**: e.g., `4.1` (leave empty to use default)
+   - **CRIU commit**: e.g., `abc123def` or `master` (overrides version if set)
+   - **CRIU shasum**: Required SHA256 checksum for the source
+   - **Build revision**: e.g., `r1`, `r2` (for build script changes, optional)
+   - **Release type**: Select `draft` (default)
+4. Click "Run workflow"
+
+## Promoting Draft to Release
+
+You can also do a release type `release` directly, in that case you don't need to promote a draft.
+
+1. Go to Releases in this repository
+2. Find your draft release
+3. Click "Edit"
+4. Uncheck "Save as draft"
+5. Click "Publish release"
+
+## Updating Default CRIU Version
+
+When promoting a CRIU version permanently (not just for testing):
+
+1. Create a PR to update the defaults in `CMakeLists.txt`:
+   - Update `CRIU_VERSION`
+   - Update `CRIU_SHASUM`
+2. After PR is merged, normal CI builds will use the new version by default, this is important so that PRs will test against the latest release CRIU version we released for.


### PR DESCRIPTION
The workflow today only allows us to 1:1 release a CRIU version.

To solve that, I want to introduce a release suffix -`r1`,  `-r2` and so on that specifies this information.

I also want to allow for the release workflow to do a manual dispatch so I can add branch protection to master (now we do it based on a commit) and so that we can do it without changing `CMakeLists.txt` all the times.